### PR TITLE
Use pkg-config to set up the extension

### DIFF
--- a/ext/libproxy/extconf.rb
+++ b/ext/libproxy/extconf.rb
@@ -1,5 +1,6 @@
 require 'mkmf'
 
+pkg_config('libproxy-1.0')
 exit 1 unless have_library('proxy')
 
 create_makefile('libproxy/libproxy_ext')


### PR DESCRIPTION
libproxy version 0.5 requires the GLib 2 and pthreads libraries and uses a different header file location. Use pkg-config to get the right compile and link flags.